### PR TITLE
Tweak Makefile to fit typical behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
-all:
+all: build
+
+build:
 	gcc hexc.c -lm -o hexc
-	sudo mv hexc /usr/local/bin
+
+install:
+	mv hexc /usr/local/bin
+
+uninstall:
+	rm /usr/local/bin/hexc
 
 clean:
-	sudo rm -f /usr/local/bin/hexc
+	rm hexc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## hexc
 Terminal program for converting to and from binary, decimal, and hexadecimal.  
 
-Simply run `make` to install and `make clean` to uninstall.  
+To build, run `make`. To install, build and run `sudo make install`.  To
+uninstall, run `sudo make uninstall`.
 
 Run `hexc {operator} {string1 string2 string3...}` to produce a converted string or series of strings.  
 


### PR DESCRIPTION
Typically, running `make` builds the program and `make clean` removes the
compiled binaries. Installation and uninstallation is typically done using
`make install` and `make uninstall`.

In addition, it is usually a better idea to not include `sudo` in the Makefile,
instead having `install` and `uninstall` rules be called with user-provided root
privileges by calling `sudo make install`. This allows users to elevate to
root-privileges in a system specific way, whether by being root, running `sudo`
or `su`.

This pull request fixes this by directing the default `all` rule to `build`,
which builds `hexc`, and implementing `install`, `uninstall` and `clean` as is
usual. It also updates the README accordingly.